### PR TITLE
Comparison benchmark running against PostgreSQL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,13 @@ lazy val bench = Project("bench", file("modules/bench"))
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      ),
+      "org.tpolecat" %% "doobie-postgres" % doobieVersion,
+      "org.tpolecat" %% "doobie-postgres-circe" % doobieVersion,
+      "org.tpolecat" %% "doobie-hikari" % doobieVersion,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.6.2",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.6.2" % "provided",
+      "org.tpolecat" %% "skunk-core" % "0.0.21",
+    ),
   )
 
 lazy val docs = project

--- a/modules/bench/src/main/resources/sql/data.sql
+++ b/modules/bench/src/main/resources/sql/data.sql
@@ -1,0 +1,22 @@
+INSERT INTO company
+(company_id, name)
+SELECT
+  ('00000000-0000-' || to_char(generate_series, 'fm0000') || '-0000-000000000000')::uuid,
+  'Company ' || generate_series
+FROM generate_series(1, 10);
+
+INSERT INTO department
+(company_id, department_id, name)
+SELECT
+  company_id,
+  (substring(company_id::text for 19) || to_char(generate_series, 'fm0000') || '-000000000000')::uuid,
+  company.name || ' Department ' || generate_series
+FROM company, generate_series(1, 20);
+
+INSERT INTO employee
+(department_id, employee_id, name)
+SELECT
+  department_id,
+  (substring(department_id::text for 24) || to_char(generate_series, 'fm000000000000'))::uuid,
+  department.name || ' Employee ' || generate_series
+FROM department, generate_series(1, 50);

--- a/modules/bench/src/main/resources/sql/tables.sql
+++ b/modules/bench/src/main/resources/sql/tables.sql
@@ -1,0 +1,22 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE company (
+  company_id UUID PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE department (
+  department_id UUID PRIMARY KEY,
+  company_id UUID NOT NULL REFERENCES company(company_id),
+  name TEXT NOT NULL
+);
+
+CREATE INDEX ON department(company_id);
+
+CREATE TABLE employee (
+  employee_id UUID PRIMARY KEY,
+  department_id UUID NOT NULL REFERENCES department(department_id),
+  name TEXT NOT NULL
+);
+
+CREATE INDEX ON employee(department_id);

--- a/modules/bench/src/main/scala/doobierolltest/Naive.scala
+++ b/modules/bench/src/main/scala/doobierolltest/Naive.scala
@@ -5,8 +5,8 @@ import shapeless._
 
 object Naive {
   def assembleUngrouped(
-    rows: Vector[DbCompany :: DbDepartment :: DbEmployee :: HNil],
-  ): Vector[Company] =
+    rows: Seq[DbCompany :: DbDepartment :: DbEmployee :: HNil],
+  ): Iterable[Company] =
     rows
       .groupBy(_.head.id)
       .values
@@ -17,11 +17,10 @@ object Naive {
           .map { sameDep =>
             val dep = sameDep.head.tail.head
             val ems = sameDep.map(_.tail.tail.head).distinct.map(Employee.fromDb)
-            Department.fromDb(dep, ems)
+            Department.fromDb(dep, ems.toVector)
           }
           .toVector
         val dbComp = sameCompany.head.head
         Company.fromDb(dbComp, departmentsOfSameCompany)
       }
-      .toVector
 }

--- a/modules/bench/src/main/scala/doobierolltest/SQLComparisonBench.scala
+++ b/modules/bench/src/main/scala/doobierolltest/SQLComparisonBench.scala
@@ -1,0 +1,286 @@
+package doobierolltest
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+
+import cats.data.{NonEmptyList, NonEmptyVector}
+import cats.effect.{Blocker, ContextShift, IO}
+import cats.kernel.Eq
+import cats.syntax.traverse._
+import doobie.hikari.HikariTransactor
+import doobie.implicits.AsyncConnectionIO
+import doobie.syntax.connectionio._
+import doobie.syntax.stream._
+import doobie.util.{Get, Read}
+import doobie.util.query.Query0
+import doobierolltest.TestDataInstances.Infallible
+import doobierolltest.model._
+import fs2.Stream
+import io.circe.Decoder
+import org.openjdk.jmh.annotations._
+import shapeless.::
+import shapeless.HNil
+import skunk.Session
+
+// docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=password -e POSTGRES_DB=doobieroll -v "$(pwd)/modules/bench/src/main/resources/sql/tables.sql:/docker-entrypoint-initdb.d/01-tables.sql" -v "$(pwd)/modules/bench/src/main/resources/sql/data.sql:/docker-entrypoint-initdb.d/02-data.sql" postgres:12
+
+object SQLComparisonBench {
+  import doobie.postgres.implicits.UuidType
+
+  private implicit val eqDbCompany: Eq[DbCompany] = Eq.fromUniversalEquals
+  private implicit val eqDbDepartment: Eq[DbDepartment] = Eq.fromUniversalEquals
+
+  private implicit val decoderEmployee: Decoder[Employee] = io.circe.generic.semiauto.deriveDecoder
+  private implicit val decoderDepartment: Decoder[Department] = io.circe.generic.semiauto.deriveDecoder
+  private implicit val decoderCompany: Decoder[Company] = io.circe.generic.semiauto.deriveDecoder
+
+  private val sql = """
+    SELECT
+      company_id,
+      company.name,
+
+      department_id,
+      company_id,
+      department.name,
+
+      employee_id,
+      department_id,
+      employee.name
+    FROM company
+    JOIN department USING (company_id)
+    JOIN employee USING (department_id)
+  """
+  private val query = Query0[DbCompany :: DbDepartment :: DbEmployee :: HNil](sql)
+  private val queryOrdered = Query0[DbCompany :: DbDepartment :: DbEmployee :: HNil](
+    sql concat " ORDER BY company_id, department_id, employee_id"
+  )
+
+  private val sqlCompany = {
+    import doobie.syntax.string._
+    fr"""
+      SELECT
+        company_id,
+        company.name
+      FROM company
+    """.query[DbCompany]
+  }
+  private def sqlDepartment(companyIds: NonEmptyVector[UUID]) = {
+    import doobie.syntax.string._
+
+    fr"""
+      SELECT
+        department_id,
+        company_id,
+        department.name
+      FROM department
+      WHERE ${doobie.util.fragments.in(fr"company_id", companyIds)}
+    """.query[DbDepartment]
+  }
+  private def sqlEmployee(departmentIds: NonEmptyVector[UUID]) = {
+    import doobie.syntax.string._
+
+    fr"""
+      SELECT
+        employee_id,
+        department_id,
+        employee.name
+      FROM employee
+      WHERE ${doobie.util.fragments.in(fr"department_id", departmentIds)}
+    """.query[DbEmployee]
+  }
+
+  private val querySkunk = {
+    import skunk.codec.all._
+    import skunk.syntax.stringcontext._
+
+    val decoderDbCompany = (uuid ~ text).gimap[DbCompany]
+    val decoderDbDepartment = (uuid ~ uuid ~ text).gimap[DbDepartment]
+    val decoderDbEmployee = (uuid ~ uuid ~ text).gimap[DbEmployee]
+    val decoder = (decoderDbCompany ~ decoderDbDepartment ~ decoderDbEmployee).map { case ((c, d), e) =>
+      c :: d :: e :: HNil
+    }
+
+    val fragment: skunk.Fragment[skunk.Void] = sql"""
+      SELECT
+        company_id,
+        company.name,
+
+        department_id,
+        company_id,
+        department.name,
+
+        employee_id,
+        department_id,
+        employee.name
+      FROM company
+      JOIN department USING (company_id)
+      JOIN employee USING (department_id)
+    """
+    fragment.query(decoder)
+  }
+
+  private val sqlJSON = """
+    SELECT
+      jsonb_build_object(
+        'id', company_id,
+        'name', company.name,
+        'departments', (
+          SELECT json_agg(jsonb_build_object(
+            'id', department_id,
+            'name', department.name,
+            'employees', (
+              SELECT json_agg(jsonb_build_object(
+                'id', employee_id,
+                'name', employee.name
+              ))
+              FROM employee
+              WHERE employee.department_id = department.department_id
+            )
+          ))
+          FROM department
+          WHERE department.company_id = company.company_id
+        )
+      )
+    FROM company
+  """
+  private val queryJSON = {
+    import doobie.postgres.circe.jsonb.implicits._
+    val read = Read.fromGet(pgDecoderGetT[Company])
+    Query0(sqlJSON)(read)
+  }
+  private val queryJSON_jsoniter = {
+    import com.github.plokhotnyuk.jsoniter_scala.macros._
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+
+    val codec: JsonValueCodec[Company] = JsonCodecMaker.make
+
+    val get = Get.Advanced.other[org.postgresql.util.PGobject](
+      NonEmptyList.of("jsonb")
+    ).map { o =>
+      val bytes = o.getValue.getBytes(StandardCharsets.UTF_8)
+      readFromArray(bytes)(codec)
+    }
+    val read = Read.fromGet(get)
+    Query0(sqlJSON)(read)
+  }
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class SQLComparisonBench {
+  import SQLComparisonBench._
+
+  private val port = 5432
+  private val database = "doobieroll"
+  private val user = "postgres"
+  private val pass = "password"
+
+  private val (transactor, _) = {
+    val ec = ExecutionContext.global
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    HikariTransactor.newHikariTransactor[IO](
+      driverClassName = "org.postgresql.Driver",
+      url = s"jdbc:postgresql://localhost:$port/$database",
+      user = user,
+      pass = pass,
+      ec,
+      Blocker.liftExecutionContext(ec)
+    )
+  }.allocated.unsafeRunSync()
+
+  private val (session, _) = {
+    import natchez.Trace.Implicits.noop
+    val ec = ExecutionContext.global
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    Session.pooled[IO](
+      host = "localhost",
+      port = port,
+      database = database,
+      user = user,
+      password = Some(pass),
+      max = 5,
+    )
+  }.allocated.unsafeRunSync()
+
+  @Benchmark
+  def naive: Iterable[Company] = {
+    val conn = query.to[Vector].map { results =>
+      Naive.assembleUngrouped(results)
+    }
+    conn.transact(transactor).unsafeRunSync()
+  }
+
+  @Benchmark
+  def roll: Vector[Company] = {
+    val conn = query.to[Vector].map { results =>
+      Infallible.companyAssembler.assemble(results)
+    }
+    conn.transact(transactor).unsafeRunSync()
+  }
+
+  @Benchmark
+  def fs2: Vector[Company] = {
+    val stream = queryOrdered.stream.transact(transactor)
+      .groupAdjacentBy(_.head)
+      .map { case (company, chunk) =>
+        val departments = Stream.chunk(chunk).groupAdjacentBy(_.tail.head).map { case (department, chunk) =>
+          val employees = chunk.map(t => Employee.fromDb(t.tail.tail.head))
+          Department.fromDb(department, employees.toVector)
+        }.compile.toVector
+        Company.fromDb(company, departments)
+      }
+    stream.compile.toVector.unsafeRunSync()
+  }
+
+  @Benchmark
+  def jsonCirce: Vector[Company] = {
+    val conn = queryJSON.to[Vector]
+    conn.transact(transactor).unsafeRunSync()
+  }
+
+  @Benchmark
+  def jsonJsoniter: Vector[Company] = {
+    val conn = queryJSON_jsoniter.to[Vector]
+    conn.transact(transactor).unsafeRunSync()
+  }
+
+  @Benchmark
+  def multipleQueries: Vector[Company] = {
+    val conn = for {
+      companies <- sqlCompany.to[Vector]
+      companyIds = NonEmptyVector.fromVector(companies.map(_.id))
+      departments <- companyIds.traverse(sqlDepartment(_).to[Vector]).map(_.getOrElse(Vector.empty))
+      departmentsByCompany = departments.groupBy(_.companyId)
+      departmentIds = NonEmptyVector.fromVector(departments.map(_.id))
+      employees <- departmentIds.traverse(sqlEmployee(_).to[Vector]).map(_.getOrElse(Vector.empty))
+      employeesByDepartment = employees.groupBy(_.departmentId)
+    } yield companies.map { c =>
+      val departments = {
+        val dbDepartments = departmentsByCompany.getOrElse(c.id, Vector.empty)
+        dbDepartments.map { d =>
+          val dbEmployees = employeesByDepartment.getOrElse(d.id, Vector.empty)
+          val employees = dbEmployees.map(Employee.fromDb)
+          Department.fromDb(d, employees)
+        }
+      }
+      Company.fromDb(c, departments)
+    }
+    conn.transact(transactor).unsafeRunSync()
+  }
+
+  @Benchmark
+  def skunkNaive: Iterable[Company] = {
+    session.use { s =>
+      s.execute(querySkunk)
+    }.map { results =>
+      Naive.assembleUngrouped(results.toVector)
+    }.unsafeRunSync()
+  }
+
+}


### PR DESCRIPTION
A simple comparison of different ways of fetching 10 companies each with
20 departments with each department having 50 employees.

```
Benchmark                            Mode  Cnt    Score    Error  Units
SQLComparisonBench.fs2              thrpt    5   65.296 ±  0.943  ops/s
SQLComparisonBench.jsonCirce        thrpt    5   15.812 ±  0.645  ops/s
SQLComparisonBench.jsonJsoniter     thrpt    5   16.531 ±  0.312  ops/s
SQLComparisonBench.multipleQueries  thrpt    5  195.955 ± 23.984  ops/s
SQLComparisonBench.naive            thrpt    5   95.241 ±  5.916  ops/s
SQLComparisonBench.roll             thrpt    5   86.137 ±  4.817  ops/s
SQLComparisonBench.skunkNaive       thrpt    5    3.307 ±  0.462  ops/s
```