### PR TITLE
Deprecate TableColumn methods that return strings

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,8 +2,8 @@ pull_request_rules:
   - name: "Merge when CI success"
     conditions:
       - author=jatcwang
-      - status-success="Build and Test (ubuntu-latest, 2.13.3, adopt@1.11)"
-      - status-success="Build and Test (ubuntu-latest, 2.12.12, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.13.4, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)"
       - label=merge-when-ci-success
     actions:
       merge:
@@ -12,8 +12,8 @@ pull_request_rules:
   - name: automatic merge for scala-steward pull requests affecting build.sbt
     conditions:
       - author=scala-steward
-      - status-success="Build and Test (ubuntu-latest, 2.13.3, adopt@1.11)"
-      - status-success="Build and Test (ubuntu-latest, 2.12.12, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.13.4, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)"
       - "#files=1"
       - files=build.sbt
     actions:
@@ -23,8 +23,8 @@ pull_request_rules:
   - name: automatic merge for scala-steward pull requests affecting project plugins.sbt
     conditions:
       - author=scala-steward
-      - status-success="Build and Test (ubuntu-latest, 2.13.3, adopt@1.11)"
-      - status-success="Build and Test (ubuntu-latest, 2.12.12, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.13.4, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)"
       - "#files=1"
       - files=project/plugins.sbt
     actions:
@@ -34,8 +34,8 @@ pull_request_rules:
   - name: semi-automatic merge for scala-steward pull requests
     conditions:
       - author=scala-steward
-      - status-success="Build and Test (ubuntu-latest, 2.13.3, adopt@1.11)"
-      - status-success="Build and Test (ubuntu-latest, 2.12.12, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.13.4, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)"
     actions:
       merge:
         method: merge
@@ -43,8 +43,8 @@ pull_request_rules:
   - name: automatic merge for scala-steward pull requests affecting project build.properties
     conditions:
       - author=scala-steward
-      - status-success="Build and Test (ubuntu-latest, 2.13.3, adopt@1.11)"
-      - status-success="Build and Test (ubuntu-latest, 2.12.12, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.13.4, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)"
       - "#files=1"
       - files=project/build.properties
     actions:
@@ -54,8 +54,8 @@ pull_request_rules:
   - name: automatic merge for scala-steward pull requests affecting .scalafmt.conf
     conditions:
       - author=scala-steward
-      - status-success="Build and Test (ubuntu-latest, 2.13.3, adopt@1.11)"
-      - status-success="Build and Test (ubuntu-latest, 2.12.12, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.13.4, adopt@1.11)"
+      - status-success="Build and Test (ubuntu-latest, 2.12.13, adopt@1.11)"
       - "#files=1"
       - files=.scalafmt.conf
     actions:

--- a/build.sbt
+++ b/build.sbt
@@ -122,6 +122,7 @@ lazy val commonSettings = Seq(
   scalacOptions ++= Seq(
     "-Ywarn-macros:after",
   ),
+  versionScheme := Some("early-semver"),
   doc / scalacOptions --= Seq("-Xfatal-warnings"),
   scalacOptions --= {
     if (sys.env.contains("CI")) {
@@ -130,6 +131,7 @@ lazy val commonSettings = Seq(
       Seq("-Xfatal-warnings")
     }
   },
+  scalacOptions ++= Seq("-Xsource:3"),
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 val zioVersion = "1.0.4-2"
 val circeVersion = "0.13.0"
-val silencerVersion = "1.7.1"
 val doobieVersion = "0.10.0"
 val scala213 = "2.13.4"
 val scala212 = "2.12.13"
@@ -131,15 +130,8 @@ lazy val commonSettings = Seq(
       Seq("-Xfatal-warnings")
     }
   },
-  scalacOptions ++= Seq("-Xsource:3"),
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
-  libraryDependencies ++= Seq(
-    compilerPlugin(
-      "com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full,
-    ),
-    "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full,
-  ),
 )
 
 lazy val noPublishSettings = Seq(

--- a/docs/docs/docs/TableColumns.md
+++ b/docs/docs/docs/TableColumns.md
@@ -66,12 +66,14 @@ object DbCompany {
 ```
 
 ```scala mdoc
-val qq: Fragment = fr"INSERT INTO company" ++
-    DbCompany.columns.listWithParenF ++
-    fr"VALUES" ++
-    DbCompany.columns.parameterizedWithParenF ++
-    fr"ON CONFLICT (id) DO UPDATE SET" ++
-    updateAllNonKeyColumns(DbCompany.columns)
+val qq: Fragment = fr"""
+  |INSERT INTO company
+  |${DbCompany.columns.listWithParenF}
+  |VALUES
+  |${DbCompany.columns.parameterizedWithParenF}
+  |ON CONFLICT (id) DO UPDATE SET
+  |${updateAllNonKeyColumns(DbCompany.columns)}
+""".stripMargin
 
 // You can define your own functions to work with the list of fields!
 private def updateAllNonKeyColumns(tableColumns: TableColumns[_]): Fragment =

--- a/modules/core/src/main/scala/doobieroll/TableColumns.scala
+++ b/modules/core/src/main/scala/doobieroll/TableColumns.scala
@@ -10,48 +10,98 @@ import doobie.Fragment
 import scala.annotation.implicitNotFound
 
 sealed abstract case class TableColumns[T](
-  tableName: String,
+  tableNameStr: String,
   allColumns: NonEmptyList[String],
 ) {
 
+  @deprecated(
+    "Use tableNameStr instead. From v0.2.* onwards this method will start returning Fragment since " +
+      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
+    since = "0.1.7",
+  )
+  def tableName: String = tableNameStr
+
+  def tableNameF: Fragment = Fragment.const(tableNameStr)
+
   /** List th fields, separated by commas. e.g. "field1,field2,field3" */
-  def list: String = allColumns.toList.mkString(",")
+  @deprecated(
+    "Use listStr instead. From v0.2.* onwards this method will start returning Fragment since " +
+      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
+    since = "0.1.7",
+  )
+  def list: String = listStr
 
-  def listF: Fragment = Fragment.const(list)
+  def listF: Fragment = Fragment.const(listStr)
 
-  /** List th fields, separated by commas and surrounded by parens.
-    * e.g. "(field1,field2,field3)"
+  def listStr: String = allColumns.toList.mkString(",")
+
+  /** List th fields, separated by commas and surrounded by parens. e.g. "(field1,field2,field3)"
     * This makes INSERT queries easier to write like "INSERT INTO mytable VALUES $\{columns.listWithParen}"
     */
-  def listWithParen: String = s"($list)"
+  @deprecated(
+    "Use listWithParenStr instead. From v0.2.* onwards this method will start returning Fragment since " +
+      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
+    since = "0.1.7",
+  )
+  def listWithParen: String = listWithParenStr
 
-  def listWithParenF: Fragment = Fragment.const(listWithParen)
+  def listWithParenF: Fragment = Fragment.const(listWithParenStr)
+
+  def listWithParenStr: String = s"($listStr)"
 
   /** Return string of the form '?,?,?' depending on how many fields there is for this TableColumn */
-  def parameterized: String = allColumns.map(_ => "?").toList.mkString(",")
+  @deprecated(
+    "Use parameterizedStr instead. From v0.2.* onwards this method will start returning Fragment since " +
+      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
+    since = "0.1.7",
+  )
+  def parameterized: String = parameterizedStr
 
   def parameterizedF: Fragment =
-    Fragment.const(parameterized)
+    Fragment.const(parameterizedStr)
 
-  def parameterizedWithParen: String =
-    s"($parameterized)"
+  def parameterizedStr: String = allColumns.map(_ => "?").toList.mkString(",")
+
+  @deprecated(
+    "Use parameterizedWithParenStr instead. From v0.2.* onwards this method will start returning Fragment since " +
+      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
+    since = "0.1.7",
+  )
+  /** Return string of the form '(?,?,?)' depending on how many fields there is for this TableColumn. */
+  def parameterizedWithParen: String = parameterizedWithParenStr
 
   def parameterizedWithParenF: Fragment =
-    Fragment.const(parameterizedWithParen)
+    Fragment.const(parameterizedWithParenStr)
 
-  /** Prefix each field with the default table name.
-    * e.g. "mytable.id, mytable.name, mytable.address"
+  def parameterizedWithParenStr: String =
+    s"($parameterizedStr)"
+
+  /** Prefix each field with the default table name. e.g. "mytable.id, mytable.name, mytable.address"
     */
-  def tableNamePrefixed: String =
-    allColumns.map(field => s"$tableName.$field").toList.mkString(",")
+  @deprecated(
+    "Use tableNamePrefixedStr instead. From v0.2.* onwards this method will start returning Fragment since " +
+      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
+    since = "0.1.7",
+  )
+  def tableNamePrefixed: String = tableNamePrefixedStr
 
-  def tableNamePrefixedF: Fragment = Fragment.const(tableNamePrefixed)
+  def tableNamePrefixedF: Fragment = Fragment.const(tableNamePrefixedStr)
+
+  def tableNamePrefixedStr: String =
+    allColumns.map(field => s"$tableNameStr.$field").toList.mkString(",")
 
   /** Prefix each field with the given string. e.g. "c.id, c.name, c.address" */
-  def prefixed(prefix: String): String =
-    allColumns.map(field => s"$prefix.$field").toList.mkString(",")
+  @deprecated(
+    "Use prefixedStr instead. From v0.2.* onwards this method will start returning Fragment since " +
+      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
+    since = "0.1.7",
+  )
+  def prefixed(prefix: String): String = prefixedStr(prefix)
 
-  def prefixedF(prefix: String): Fragment = Fragment.const(prefixed(prefix))
+  def prefixedF(prefix: String): Fragment = Fragment.const(prefixedStr(prefix))
+
+  def prefixedStr(prefix: String): String =
+    allColumns.map(field => s"$prefix.$field").toList.mkString(",")
 
 }
 

--- a/modules/core/src/main/scala/doobieroll/snippets/CommonSnippets.scala
+++ b/modules/core/src/main/scala/doobieroll/snippets/CommonSnippets.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 trait CommonSnippets {
   def selectColumnsFrom(tableColumns: TableColumns[_]): Fragment =
     Fragment.const(
-      s"SELECT ${tableColumns.list} FROM ${tableColumns.tableName}",
+      s"SELECT ${tableColumns.listStr} FROM ${tableColumns.tableNameStr}",
     )
 
   def selectColumns(

--- a/modules/coretest/src/test/scala/doobierolltest/DoobieIntegrationSpec.scala
+++ b/modules/coretest/src/test/scala/doobierolltest/DoobieIntegrationSpec.scala
@@ -170,33 +170,32 @@ object DoobieIntegrationSpec extends DefaultRunnableSpec {
 
   def insertDbCompany: Update[DbCompany] = {
     val cols = DbCompany.columns
-    Update[DbCompany](
-      s"INSERT INTO ${cols.tableName} ${cols.listWithParen} " +
-        s"VALUES ${cols.parameterizedWithParen}",
+    Update(
+      s"INSERT INTO ${cols.tableNameStr} ${cols.listWithParenStr} VALUES ${cols.parameterizedWithParenStr}",
     )
   }
 
   def insertDbDepartment: Update[DbDepartment] = {
     val cols = DbDepartment.columns
     Update[DbDepartment](
-      s"INSERT INTO ${cols.tableName} ${cols.listWithParen} " +
-        s"VALUES ${cols.parameterizedWithParen}",
+      s"INSERT INTO ${cols.tableNameStr} ${cols.listWithParenStr} " +
+        s"VALUES ${cols.parameterizedWithParenStr}",
     )
   }
 
   def insertDbEmployee: Update[DbEmployee] = {
     val cols = DbEmployee.columns
     Update[DbEmployee](
-      s"INSERT INTO ${cols.tableName} ${cols.listWithParen} " +
-        s"VALUES ${cols.parameterizedWithParen}",
+      s"INSERT INTO ${cols.tableNameStr} ${cols.listWithParenStr} " +
+        s"VALUES ${cols.parameterizedWithParenStr}",
     )
   }
 
   def insertDbInvoice: Update[DbInvoice] = {
     val cols = DbInvoice.columns
     Update[DbInvoice](
-      s"INSERT INTO ${cols.tableName} ${cols.listWithParen} " +
-        s"VALUES ${cols.parameterizedWithParen}",
+      s"INSERT INTO ${cols.tableNameStr} ${cols.listWithParenStr} " +
+        s"VALUES ${cols.parameterizedWithParenStr}",
     )
   }
 
@@ -217,9 +216,9 @@ object DoobieIntegrationSpec extends DefaultRunnableSpec {
     runSql(
       Query0[Dbs](
         s"""SELECT
-           ${companyCols.prefixed("c")},
-           ${departmentCols.prefixed("d")},
-           ${employeeCols.prefixed("e")}
+           ${companyCols.prefixedStr("c")},
+           ${departmentCols.prefixedStr("d")},
+           ${employeeCols.prefixedStr("e")}
             FROM company as c
          $joinType JOIN department AS d ON c.id = d.company_id
          $joinType JOIN employee AS e ON d.id = e.department_id

--- a/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
+++ b/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
@@ -9,17 +9,17 @@ object TableColumnsSpec extends DefaultRunnableSpec {
 
   def spec =
     suite("TableColumnSpec")(
-      test("'list' returns comma separate column names") {
-        assertStringEqual(TestClass.columns.list, "a,str_field,snake_case,pascal_case")
+      test("'listStr' returns comma separate column names") {
+        assertStringEqual(TestClass.columns.listStr, "a,str_field,snake_case,pascal_case")
       },
       test("'listF' returns comma separate column names Fragment") {
         assertFragmentSqlEqual(TestClass.columns.listF, "a,str_field,snake_case,pascal_case ")
       },
       test(
-        "'listWithParen' returns comma separate column names, surround by parenthesis",
+        "'listWithParenStr' returns comma separate column names, surround by parenthesis",
       ) {
         assertStringEqual(
-          TestClass.columns.listWithParen,
+          TestClass.columns.listWithParenStr,
           "(a,str_field,snake_case,pascal_case)",
         )
       },
@@ -31,9 +31,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
           "(a,str_field,snake_case,pascal_case) ",
         )
       },
-      test("'prefixed' returns list of field all prefixed") {
+      test("'prefixedStr' returns list of field all prefixed") {
         assertStringEqual(
-          TestClass.columns.prefixed("pre"),
+          TestClass.columns.prefixedStr("pre"),
           "pre.a,pre.str_field,pre.snake_case,pre.pascal_case",
         )
       },
@@ -43,9 +43,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
           "pre.a,pre.str_field,pre.snake_case,pre.pascal_case ",
         )
       },
-      test("'tableNamePrefixed' returns ") {
+      test("'tableNamePrefixedStr' returns ") {
         assertStringEqual(
-          TestClass.columns.tableNamePrefixed,
+          TestClass.columns.tableNamePrefixedStr,
           "test_class.a,test_class.str_field,test_class.snake_case,test_class.pascal_case",
         )
       },
@@ -56,9 +56,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         )
       },
       test(
-        "'parameterized' returns same number of '?' as the number of columns, separated by commas",
+        "'parameterizedStr' returns same number of '?' as the number of columns, separated by commas",
       ) {
-        assertStringEqual(TestClass.columns.parameterized, "?,?,?,?")
+        assertStringEqual(TestClass.columns.parameterizedStr, "?,?,?,?")
       },
       test(
         "'parameterizedF' returns Fragment with same number of '?' as the number of columns, separated by commas",
@@ -66,9 +66,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         assertFragmentSqlEqual(TestClass.columns.parameterizedF, "?,?,?,? ")
       },
       test(
-        "'parameterizedWithParen' is similar to 'parameterized' but the output is additionally surrounded by parenthesis",
+        "'parameterizedWithParenStr' is similar to 'parameterized' but the output is additionally surrounded by parenthesis",
       ) {
-        assertStringEqual(TestClass.columns.parameterizedWithParen, "(?,?,?,?)")
+        assertStringEqual(TestClass.columns.parameterizedWithParenStr, "(?,?,?,?)")
       },
       test(
         "'parameterizedWithParenF' is similar to 'parameterized' but the output is additionally surrounded by parenthesis",


### PR DESCRIPTION
Users should migrate to use alternative methods that has *str suffix instead if they need it (or just use Fragment interpolation directly)