### PR TITLE
Add method to retrieve a column name from a string

### DIFF
--- a/docs/docs/docs/TableColumns.md
+++ b/docs/docs/docs/TableColumns.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title:  "TableColumns"
+title: "TableColumns"
 permalink: docs/tablecolumns
 ---
 
@@ -30,7 +30,7 @@ INSERT INTO company (
 ) VALUES (
   ?, ?, ?, ?, ?
 )
-ON CONFLICT (id) DO UPDATE SET 
+ON CONFLICT (id) DO UPDATE SET
   id = EXCLUDED.id,
   name = EXCLUDED.name,
   phone_number = EXCLUDED.phone_number,
@@ -86,3 +86,18 @@ private def updateAllNonKeyColumns(tableColumns: TableColumns[_]): Fragment =
 Other than having less boilerplate, the main benefit of using `TableColumns` is **consistency**.
 Since field names and order are consistent across all use sites, we can avoid out of order fields
 causing bugs.
+
+## Sorting with TableColumns
+
+Usually when sorting a table, the column (or columns) you sort on are not known at compile time. This means you usually need to validate the column name at runtime before using it in the query.
+`TableColumns` can help in this case as well:
+
+```scala mdoc
+def sortCompanies(sortingField: String): Either[NoSuchField, Fragment] =
+  DbCompany.columns.fromFieldF(sortingField).map { sortingColumnFr =>
+    fr"""
+      |SELECT ${DbCompany.columns.listStr} FROM company
+      |ORDER BY $sortingColumnFr ASC
+    """.stripMargin
+  }
+```

--- a/docs/docs/docs/TableColumns.md
+++ b/docs/docs/docs/TableColumns.md
@@ -93,7 +93,7 @@ Usually when sorting a table, the column (or columns) you sort on are not known 
 `TableColumns` can help in this case as well:
 
 ```scala mdoc:invisible
-import doobieroll.NoSuchField
+import doobieroll.TableColumns.NoSuchField
 ```
 
 ```scala mdoc

--- a/docs/docs/docs/TableColumns.md
+++ b/docs/docs/docs/TableColumns.md
@@ -92,6 +92,10 @@ causing bugs.
 Usually when sorting a table, the column (or columns) you sort on are not known at compile time. This means you usually need to validate the column name at runtime before using it in the query.
 `TableColumns` can help in this case as well:
 
+```scala mdoc:invisible
+import doobieroll.NoSuchField
+```
+
 ```scala mdoc
 def sortCompanies(sortingField: String): Either[NoSuchField, Fragment] =
   DbCompany.columns.fromFieldF(sortingField).map { sortingColumnFr =>

--- a/modules/core/src/main/scala/doobieroll/TableColumns.scala
+++ b/modules/core/src/main/scala/doobieroll/TableColumns.scala
@@ -108,8 +108,8 @@ sealed abstract case class TableColumns[T](
     allColumns.map(field => s"$prefix.$field").toList.mkString(",")
 
   /** Return the column name associated with the provided field */
-  def fromFieldF(field: String): Either[doobieroll.TableColumns.NoSuchField, Fragment] =
-    fromFieldStr(field).map(Fragment.const0(_))
+  def fromFieldF(field: String): Either[NoSuchField, Fragment] =
+    fromFieldStr(field).map(Fragment.const(_))
 
   def fromFieldStr(field: String): Either[NoSuchField, String] =
     Either.cond(fieldNames.contains_(field), transform(field), NoSuchField())

--- a/modules/core/src/main/scala/doobieroll/TableColumns.scala
+++ b/modules/core/src/main/scala/doobieroll/TableColumns.scala
@@ -7,6 +7,7 @@ import shapeless.ops.hlist.{Mapper, ToTraversable}
 import shapeless.ops.record.Keys
 import shapeless.tag.Tagged
 import doobie.Fragment
+import doobieroll.TableColumns.NoSuchField
 
 import scala.annotation.implicitNotFound
 
@@ -107,7 +108,7 @@ sealed abstract case class TableColumns[T](
     allColumns.map(field => s"$prefix.$field").toList.mkString(",")
 
   /** Return the column name associated with the provided field */
-  def fromFieldF(field: String): Either[NoSuchField, Fragment] =
+  def fromFieldF(field: String): Either[doobieroll.TableColumns.NoSuchField, Fragment] =
     fromFieldStr(field).map(Fragment.const0(_))
 
   def fromFieldStr(field: String): Either[NoSuchField, String] =
@@ -148,6 +149,8 @@ object TableColumns {
     new TableColumns[T](tableName, names, transform) {}
   }
 
+  case class NoSuchField() extends RuntimeException
+
 }
 
 // A separate class to prevent automatic derivation
@@ -185,5 +188,3 @@ private object MkTableColumns {
   }
 
 }
-
-case class NoSuchField() extends RuntimeException

--- a/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
+++ b/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
@@ -3,7 +3,9 @@ package doobierolltest
 import doobieroll.TableColumns
 import shapeless.test.illTyped
 import zio.test._
+import zio.test.Assertion._
 import testutils.FragmentAssertions._
+import doobieroll.NoSuchField
 
 object TableColumnsSpec extends DefaultRunnableSpec {
 
@@ -74,6 +76,28 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         "'parameterizedWithParenF' is similar to 'parameterized' but the output is additionally surrounded by parenthesis",
       ) {
         assertFragmentSqlEqual(TestClass.columns.parameterizedWithParenF, "(?,?,?,?) ")
+      },
+      test(
+        "'fromFieldStr' returns the column name for an existing field",
+      ) {
+        assert(TestClass.columns.fromFieldStr("PascalCase"))(isRight(equalTo("pascal_case")))
+      },
+      test(
+        "'fromFieldStr' returns an error for a non existing field",
+      ) {
+        assert(TestClass.columns.fromFieldStr("notAField"))(isLeft(equalTo(NoSuchField())))
+      },
+      test(
+        "'fromFieldF' returns the column name fragment for an existing field",
+      ) {
+        assert(TestClass.columns.fromFieldF("PascalCase").map(_.query.sql))(
+          isRight(equalTo("pascal_case")),
+        )
+      },
+      test(
+        "'fromFieldF' returns an error for a non existing field",
+      ) {
+        assert(TestClass.columns.fromFieldF("notAField"))(isLeft(equalTo(NoSuchField())))
       },
       test(
         "joinMap",

--- a/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
+++ b/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
@@ -1,11 +1,11 @@
 package doobierolltest
 
 import doobieroll.TableColumns
+import doobieroll.TableColumns.NoSuchField
 import shapeless.test.illTyped
 import zio.test._
 import zio.test.Assertion._
 import testutils.FragmentAssertions._
-import doobieroll.NoSuchField
 
 object TableColumnsSpec extends DefaultRunnableSpec {
 

--- a/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
+++ b/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
@@ -91,7 +91,7 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         "'fromFieldF' returns the column name fragment for an existing field",
       ) {
         assert(TestClass.columns.fromFieldF("PascalCase").map(_.query.sql))(
-          isRight(equalTo("pascal_case")),
+          isRight(equalTo("pascal_case ")),
         )
       },
       test(


### PR DESCRIPTION
Hi, thank you for this awesome library!

I added the possibility of validating column names at runtime to TableColumns (useful for example when you want to sort on a column that's unknown at compile time).

One thing that I'm not so sure about is that in order to be able to transform the class field name to the column name, I needed to move the transform function into the TableColumns class.

Let me know what you think!