### PR TITLE
TableColumns - methods like list, prefixed now return a Fragment instead of String

### DIFF
--- a/docs/docs/docs/Snippets.md
+++ b/docs/docs/docs/Snippets.md
@@ -57,7 +57,7 @@ selectColumnsFrom(DbCompany.columns)
 
 ```scala mdoc
 selectColumns(
-  DbCompany.columns.prefixedF("c"),
-  DbEmployee.columns.prefixedF("e")
+  DbCompany.columns.prefixed("c"),
+  DbEmployee.columns.prefixed("e")
 ) ++ fr"FROM company c LEFT JOIN employee e ON company.id = employee.company_id"
 ```

--- a/docs/docs/docs/TableColumns.md
+++ b/docs/docs/docs/TableColumns.md
@@ -68,9 +68,9 @@ object DbCompany {
 ```scala mdoc
 val qq: Fragment = fr"""
   |INSERT INTO company
-  |${DbCompany.columns.listWithParenF}
+  |${DbCompany.columns.listWithParen}
   |VALUES
-  |${DbCompany.columns.parameterizedWithParenF}
+  |${DbCompany.columns.parameterizedWithParen}
   |ON CONFLICT (id) DO UPDATE SET
   |${updateAllNonKeyColumns(DbCompany.columns)}
 """.stripMargin
@@ -98,7 +98,7 @@ import doobieroll.TableColumns.NoSuchField
 
 ```scala mdoc
 def sortCompanies(sortingField: String): Either[NoSuchField, Fragment] =
-  DbCompany.columns.fromFieldF(sortingField).map { sortingColumnFr =>
+  DbCompany.columns.fromField(sortingField).map { sortingColumnFr =>
     fr"""
       |SELECT ${DbCompany.columns.listStr} FROM company
       |ORDER BY $sortingColumnFr ASC

--- a/modules/core/src/main/scala/doobieroll/TableColumns.scala
+++ b/modules/core/src/main/scala/doobieroll/TableColumns.scala
@@ -18,63 +18,28 @@ sealed abstract case class TableColumns[T](
 ) {
   val allColumns: NonEmptyList[String] = fieldNames.map(transform)
 
-  @deprecated(
-    "Use tableNameStr instead. From v0.2.* onwards this method will start returning Fragment since " +
-      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
-    since = "0.1.7",
-  )
-  def tableName: String = tableNameStr
-
   def tableNameF: Fragment = Fragment.const(tableNameStr)
 
   /** List th fields, separated by commas. e.g. "field1,field2,field3" */
-  @deprecated(
-    "Use listStr instead. From v0.2.* onwards this method will start returning Fragment since " +
-      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
-    since = "0.1.7",
-  )
-  def list: String = listStr
-
-  def listF: Fragment = Fragment.const(listStr)
+  def list: Fragment = Fragment.const(listStr)
 
   def listStr: String = allColumns.toList.mkString(",")
 
   /** List th fields, separated by commas and surrounded by parens. e.g. "(field1,field2,field3)"
     * This makes INSERT queries easier to write like "INSERT INTO mytable VALUES $\{columns.listWithParen}"
     */
-  @deprecated(
-    "Use listWithParenStr instead. From v0.2.* onwards this method will start returning Fragment since " +
-      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
-    since = "0.1.7",
-  )
-  def listWithParen: String = listWithParenStr
-
-  def listWithParenF: Fragment = Fragment.const(listWithParenStr)
+  def listWithParen: Fragment = Fragment.const(listWithParenStr)
 
   def listWithParenStr: String = s"($listStr)"
 
   /** Return string of the form '?,?,?' depending on how many fields there is for this TableColumn */
-  @deprecated(
-    "Use parameterizedStr instead. From v0.2.* onwards this method will start returning Fragment since " +
-      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
-    since = "0.1.7",
-  )
-  def parameterized: String = parameterizedStr
-
-  def parameterizedF: Fragment =
+  def parameterized: Fragment =
     Fragment.const(parameterizedStr)
 
   def parameterizedStr: String = allColumns.map(_ => "?").toList.mkString(",")
 
-  @deprecated(
-    "Use parameterizedWithParenStr instead. From v0.2.* onwards this method will start returning Fragment since " +
-      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
-    since = "0.1.7",
-  )
   /** Return string of the form '(?,?,?)' depending on how many fields there is for this TableColumn. */
-  def parameterizedWithParen: String = parameterizedWithParenStr
-
-  def parameterizedWithParenF: Fragment =
+  def parameterizedWithParen: Fragment =
     Fragment.const(parameterizedWithParenStr)
 
   def parameterizedWithParenStr: String =
@@ -82,33 +47,19 @@ sealed abstract case class TableColumns[T](
 
   /** Prefix each field with the default table name. e.g. "mytable.id, mytable.name, mytable.address"
     */
-  @deprecated(
-    "Use tableNamePrefixedStr instead. From v0.2.* onwards this method will start returning Fragment since " +
-      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
-    since = "0.1.7",
-  )
-  def tableNamePrefixed: String = tableNamePrefixedStr
-
-  def tableNamePrefixedF: Fragment = Fragment.const(tableNamePrefixedStr)
+  def tableNamePrefixed: Fragment = Fragment.const(tableNamePrefixedStr)
 
   def tableNamePrefixedStr: String =
     allColumns.map(field => s"$tableNameStr.$field").toList.mkString(",")
 
   /** Prefix each field with the given string. e.g. "c.id, c.name, c.address" */
-  @deprecated(
-    "Use prefixedStr instead. From v0.2.* onwards this method will start returning Fragment since " +
-      "doobie 0.9.0 allows you to directly interpolate Fragment in fr interpolators",
-    since = "0.1.7",
-  )
-  def prefixed(prefix: String): String = prefixedStr(prefix)
-
-  def prefixedF(prefix: String): Fragment = Fragment.const(prefixedStr(prefix))
+  def prefixed(prefix: String): Fragment = Fragment.const(prefixedStr(prefix))
 
   def prefixedStr(prefix: String): String =
     allColumns.map(field => s"$prefix.$field").toList.mkString(",")
 
   /** Return the column name associated with the provided field */
-  def fromFieldF(field: String): Either[NoSuchField, Fragment] =
+  def fromField(field: String): Either[NoSuchField, Fragment] =
     fromFieldStr(field).map(Fragment.const(_))
 
   def fromFieldStr(field: String): Either[NoSuchField, String] =

--- a/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
+++ b/modules/coretest/src/test/scala/doobierolltest/TableColumnsSpec.scala
@@ -14,8 +14,8 @@ object TableColumnsSpec extends DefaultRunnableSpec {
       test("'listStr' returns comma separate column names") {
         assertStringEqual(TestClass.columns.listStr, "a,str_field,snake_case,pascal_case")
       },
-      test("'listF' returns comma separate column names Fragment") {
-        assertFragmentSqlEqual(TestClass.columns.listF, "a,str_field,snake_case,pascal_case ")
+      test("'list' returns comma separate column names Fragment") {
+        assertFragmentSqlEqual(TestClass.columns.list, "a,str_field,snake_case,pascal_case ")
       },
       test(
         "'listWithParenStr' returns comma separate column names, surround by parenthesis",
@@ -26,10 +26,10 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         )
       },
       test(
-        "'listWithParenF' returns Fragment of comma separate column names, surround by parenthesis",
+        "'listWithParen' returns Fragment of comma separate column names, surround by parenthesis",
       ) {
         assertFragmentSqlEqual(
-          TestClass.columns.listWithParenF,
+          TestClass.columns.listWithParen,
           "(a,str_field,snake_case,pascal_case) ",
         )
       },
@@ -39,9 +39,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
           "pre.a,pre.str_field,pre.snake_case,pre.pascal_case",
         )
       },
-      test("'prefixedF' returns list of field all prefixed Fragment") {
+      test("'prefixed' returns list of field all prefixed Fragment") {
         assertFragmentSqlEqual(
-          TestClass.columns.prefixedF("pre"),
+          TestClass.columns.prefixed("pre"),
           "pre.a,pre.str_field,pre.snake_case,pre.pascal_case ",
         )
       },
@@ -51,9 +51,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
           "test_class.a,test_class.str_field,test_class.snake_case,test_class.pascal_case",
         )
       },
-      test("'tableNamePrefixedF' returns ") {
+      test("'tableNamePrefixed' returns ") {
         assertFragmentSqlEqual(
-          TestClass.columns.tableNamePrefixedF,
+          TestClass.columns.tableNamePrefixed,
           "test_class.a,test_class.str_field,test_class.snake_case,test_class.pascal_case ",
         )
       },
@@ -63,9 +63,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         assertStringEqual(TestClass.columns.parameterizedStr, "?,?,?,?")
       },
       test(
-        "'parameterizedF' returns Fragment with same number of '?' as the number of columns, separated by commas",
+        "'parameterized' returns Fragment with same number of '?' as the number of columns, separated by commas",
       ) {
-        assertFragmentSqlEqual(TestClass.columns.parameterizedF, "?,?,?,? ")
+        assertFragmentSqlEqual(TestClass.columns.parameterized, "?,?,?,? ")
       },
       test(
         "'parameterizedWithParenStr' is similar to 'parameterized' but the output is additionally surrounded by parenthesis",
@@ -73,9 +73,9 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         assertStringEqual(TestClass.columns.parameterizedWithParenStr, "(?,?,?,?)")
       },
       test(
-        "'parameterizedWithParenF' is similar to 'parameterized' but the output is additionally surrounded by parenthesis",
+        "'parameterizedWithParen' is similar to 'parameterized' but the output is additionally surrounded by parenthesis",
       ) {
-        assertFragmentSqlEqual(TestClass.columns.parameterizedWithParenF, "(?,?,?,?) ")
+        assertFragmentSqlEqual(TestClass.columns.parameterizedWithParen, "(?,?,?,?) ")
       },
       test(
         "'fromFieldStr' returns the column name for an existing field",
@@ -88,16 +88,16 @@ object TableColumnsSpec extends DefaultRunnableSpec {
         assert(TestClass.columns.fromFieldStr("notAField"))(isLeft(equalTo(NoSuchField())))
       },
       test(
-        "'fromFieldF' returns the column name fragment for an existing field",
+        "'fromField' returns the column name fragment for an existing field",
       ) {
-        assert(TestClass.columns.fromFieldF("PascalCase").map(_.query.sql))(
+        assert(TestClass.columns.fromField("PascalCase").map(_.query.sql))(
           isRight(equalTo("pascal_case ")),
         )
       },
       test(
-        "'fromFieldF' returns an error for a non existing field",
+        "'fromField' returns an error for a non existing field",
       ) {
-        assert(TestClass.columns.fromFieldF("notAField"))(isLeft(equalTo(NoSuchField())))
+        assert(TestClass.columns.fromField("notAField"))(isLeft(equalTo(NoSuchField())))
       },
       test(
         "joinMap",

--- a/modules/coretest/src/test/scala/doobierolltest/snippets/CommonSnippetSpec.scala
+++ b/modules/coretest/src/test/scala/doobierolltest/snippets/CommonSnippetSpec.scala
@@ -26,7 +26,7 @@ object CommonSnippetSpec extends DefaultRunnableSpec {
           "Outputs 'SELECT' followed by the provided fragment when a single fragment is provided",
         ) {
           val result = selectColumns(
-            TwoField.columns.prefixedF("p"),
+            TwoField.columns.prefixed("p"),
           )
           assertFragmentSqlEqual(result, "SELECT p.f1,p.f2 ")
         },
@@ -34,8 +34,8 @@ object CommonSnippetSpec extends DefaultRunnableSpec {
           "Outputs 'SELECT' followed by the provided fragments joined by ',' when provided with multiple fragments",
         ) {
           val result = selectColumns(
-            OneField.columns.listF,
-            TwoField.columns.prefixedF("p"),
+            OneField.columns.list,
+            TwoField.columns.prefixed("p"),
           )
           assertFragmentSqlEqual(result, "SELECT f1 ,p.f1,p.f2 ")
         },


### PR DESCRIPTION
All method that had suffix F (listF, prefixedF) which used to return Fragments are now removed.